### PR TITLE
Use paymentMethod.isAlternative() in place of paymentMethod.isCustom() 

### DIFF
--- a/partials/shop-paymentform.htm
+++ b/partials/shop-paymentform.htm
@@ -35,7 +35,7 @@
             },
             paymentMethod
         ) }}
-    {% elseif paymentMethod.isCustom() %}
+    {% elseif paymentMethod.isAlternative() %}
         {% set name = paymentMethod.getFrontendPartialName() %}
         {{ partial(name, {paymentMethod: paymentMethod, payment: payment}) }}
     {% endif %}


### PR DESCRIPTION
This:
- Uses `paymentMethod.isAlternative()` in place of `paymentMethod.isCustom()` for upcoming changes.

### Test Checklist
- [ ] Verify payment methods render properly for alternative payment methods.
- [ ] Regression test payment methods render properly for standard payment methods.